### PR TITLE
impr: add url shortener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ SUBDOMAIN_SURVEY=survey.
 SUBDOMAIN_GRAFANA=grafana.
 SUBDOMAIN_PROMETHEUS=prometheus.
 SUBDOMAIN_BITWARDEN=pass.
+SUBDOMAIN_SHORTENER=a.
 
 # Paths in the filesystem
 PATH_OMS_GLOBAL=oms-global/docker/
@@ -35,6 +36,7 @@ PATH_OMS_ELASTIC=oms-elastic/docker/
 PATH_OMS_STATUS=oms-status/docker/
 PATH_OMS_MONITOR=oms-monitor/docker/
 PATH_OMS_SECURITY=oms-security/docker/
+PATH_OMS_SHORTENER=oms-shortener/docker/
 
 # Credentials external services
 USER_SENDGRID=
@@ -54,6 +56,7 @@ PW_GRAFANA=5ecr3t
 PW_BITWARDEN=5ecr3t
 # take the following with:    openssl rand -base64 48
 PW_BITWARDEN_ADMINPANEL=iiHHglM6R5fysxzj+QNhuBHF6PoOq+VsacQQ18CM5MnsWVopK96Tqz2j9ri6xiMt
+PW_YOURLS=5ecr3t
 
 # Other variables
 COMPOSE_PROJECT_NAME=myaegee

--- a/oms-shortener/docker/docker-compose.yml
+++ b/oms-shortener/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 #     labels:
 #       - "traefik.backend=nginx-yourls"
 #       - "traefik.port=8080"
-#       - "traefik.frontend.rule=Host:${SUBDOMAIN_YOURLS}${BASE_URL};PathPrefix:/"
+#       - "traefik.frontend.rule=Host:${SUBDOMAIN_SHORTENER}${BASE_URL};PathPrefix:/"
 #       - "traefik.frontend.priority=110"
 #       - "traefik.enable=true"
 
@@ -23,14 +23,14 @@ services:
             YOURLS_DB_HOST: maria-yourls
             YOURLS_DB_USER: yourls
             YOURLS_DB_PASS: ${PW_YOURLS}
-            YOURLS_SITE: https://${SUBDOMAIN_YOURLS}${BASE_URL}
+            YOURLS_SITE: https://${SUBDOMAIN_SHORTENER}${BASE_URL}
             YOURLS_USER: admin
             YOURLS_PASS: ${PW_YOURLS}
             YOURLS_PRIVATE: true
         labels:
            - "traefik.backend=yourls"
            - "traefik.port=80"
-           - "traefik.frontend.rule=Host:${SUBDOMAIN_YOURLS}${BASE_URL};PathPrefix:/"
+           - "traefik.frontend.rule=Host:${SUBDOMAIN_SHORTENER}${BASE_URL};PathPrefix:/"
            - "traefik.frontend.priority=110"
            - "traefik.enable=true"
 

--- a/oms-shortener/docker/docker-compose.yml
+++ b/oms-shortener/docker/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.2'
+services:
+   
+#   nginx-yourls: #could be that it has some cachet bullshit still
+#     image: aegee/nginx-webserver:latest 
+#     restart: always
+#     environment:
+#       PHPFPM_HOST: yourls
+#     depends_on:
+#       - yourls
+#     labels:
+#       - "traefik.backend=nginx-yourls"
+#       - "traefik.port=8080"
+#       - "traefik.frontend.rule=Host:${SUBDOMAIN_YOURLS}${BASE_URL};PathPrefix:/"
+#       - "traefik.frontend.priority=110"
+#       - "traefik.enable=true"
+
+    yourls:
+        restart: on-failure
+        image: yourls:1.7
+#       image: yourls:1.7-fpm-alpine
+        environment:
+            YOURLS_DB_HOST: maria-yourls
+            YOURLS_DB_USER: yourls
+            YOURLS_DB_PASS: ${PW_YOURLS}
+            YOURLS_SITE: https://${SUBDOMAIN_YOURLS}${BASE_URL}
+            YOURLS_USER: admin
+            YOURLS_PASS: ${PW_YOURLS}
+            YOURLS_PRIVATE: true
+        labels:
+           - "traefik.backend=yourls"
+           - "traefik.port=80"
+           - "traefik.frontend.rule=Host:${SUBDOMAIN_YOURLS}${BASE_URL};PathPrefix:/"
+           - "traefik.frontend.priority=110"
+           - "traefik.enable=true"
+
+    maria-yourls:
+        image: mariadb:10.4
+        restart: always
+        environment:
+          MYSQL_DATABASE: "yourls"
+          MYSQL_USER: "yourls"
+          MYSQL_PASSWORD: ${PW_YOURLS}
+          MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+        volumes:
+          - maria-yourls:/var/lib/mysql
+
+volumes:
+  maria-yourls:
+    driver: local
+
+networks:
+  default:
+    external:
+      name: OMS


### PR DESCRIPTION
TODO: add reverse proxy. As of now the nginx image
is the one from cachet so it may be dirty.
To just use the software, the 'normal' version is
there though that contains apache inside, which is
overkill. Use yourls:1.7-fpm-alpine with nginx next